### PR TITLE
Composable, stream based retry delay system

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ This will try the block, and return the result, as soon as it succeeds. On a fai
 #### Example -- linear backoff
 
 ```elixir
-result = retry with: lin_backoff(10, 1.5) |> cap(1000) |> Stream.take(10) do
+result = retry with: lin_backoff(10, 2) |> cap(1000) |> Stream.take(10) do
   ExternalApi.do_something # fails if other system is down
 end
 ```
 
-This example increases the delay with each retry by 1.5x, with a initial delay of 10 milliseconds, caps the delay at 1 seconds and gives up after 10 tries.
+This example doubles the delay with each retry, starting with 10 milliseconds, caps the delay at 1 second and gives up after 10 tries.
 
 #### Delay streams
 

--- a/README.md
+++ b/README.md
@@ -27,16 +27,16 @@ The `retry(with: _, do: _)` macro provides a way to retry a block of code on fai
 #### Example -- exponential backoff
 
 ```elixir
-result = retry exp_backoff |> randomize |> expiry(10000) do
+result = retry with: exp_backoff |> randomize |> expiry(10000) do
   ExternalApi.do_something # fails if other system is down
 end
 ```
-This will try the block, and return the result, as soon as it succeeds. On a failure this example will wait an exponentially increasing amount of time (`exp_backoff/0`). Each delay will be randomly adjusted by a duration within +/-10% (`randomize/2`). And finally it will give up entirely if the block has not succeeded with in 10 seconds (`expiry/2`).
+This will try the block, and return the result, as soon as it succeeds. On a failure this example will wait an exponentially increasing amount of time (`exp_backoff/0`). Each delay will be randomly adjusted to remain within +/-10% of its original value (`randomize/2`). And finally it will give up entirely if the block has not succeeded with in 10 seconds (`expiry/2`).
 
 #### Example -- linear backoff
 
 ```elixir
-result = retry lin_backoff(10, 1.5) |> cap(1000) |> Stream.take(10) do
+result = retry with: lin_backoff(10, 1.5) |> cap(1000) |> Stream.take(10) do
   ExternalApi.do_something # fails if other system is down
 end
 ```
@@ -50,7 +50,7 @@ The `with:` option of `retry` accepts any `Stream` that yields integers. These i
 ##### Example
 
 ```elixir
-result = retry Stream.cycle([500]) do
+result = retry with: Stream.cycle([500]) do
   ExternalApi.do_something # fails if other system is down
 end
 ```

--- a/README.md
+++ b/README.md
@@ -20,23 +20,42 @@ Check out the [API reference](https://hexdocs.pm/retry/Retry.html) for the lates
 
 ## Features
 
-#### Linear retry
+### Retrying
 
-```
-result = retry 5 in 500 do
-  SomeModule.flaky_function # Either raises a transient runtime error or returns an error tuple
+The `retry(with: _, do: _)` macro provides a way to retry a block of code on failure with a variety of delay and give up behaviors. The execution of a block is considered a failure if it returns `:error`, `{:error, _}` or raises a runtime error.
+
+#### Example -- exponential backoff
+
+```elixir
+result = retry exp_backoff |> randomize |> expiry(10000) do
+  ExternalApi.do_something # fails if other system is down
 end
 ```
-The first argument (5) is the number of retries and the second (500) is the period between attempts in milliseconds.
+This will try the block, and return the result, as soon as it succeeds. On a failure this example will wait an exponentially increasing amount of time (`exp_backoff/0`). Each delay will be randomly adjusted by a duration within +/-10% (`randomize/2`). And finally it will give up entirely if the block has not succeeded with in 10 seconds (`expiry/2`).
 
-#### Exponential backoff
+#### Example -- linear backoff
 
-```
-result = backoff 1000 do
-  SomeModule.flaky_function # Either raises a transient runtime error or returns an error tuple
+```elixir
+result = retry lin_backoff(10, 1.5) |> cap(1000) |> Stream.take(10) do
+  ExternalApi.do_something # fails if other system is down
 end
 ```
-The argument is the timeout (in milliseconds) before giving up. `backoff` accepts a optional argument `delay_cap` which is the maximum delay (in milliseconds) between attempts.
 
-#### Circuit breaker
-Work in progress.
+This example increases the delay with each retry by 1.5x, with a initial delay of 10 milliseconds, caps the delay at 1 seconds and gives up after 10 tries.
+
+#### Delay streams
+
+The `with:` option of `retry` accepts any `Stream` that yields integers. These integers will be interpreted as the amount of time to delay before retrying a failed operation. When the stream is exhausted `retry` will give up, returning the last value of the block.
+
+##### Example
+
+```elixir
+result = retry Stream.cycle([500]) do
+  ExternalApi.do_something # fails if other system is down
+end
+```
+
+This will retry failures forever, waiting .5 seconds between attempts.
+
+
+`Retry.DelayStreams` provides a set of fully composable helper functions for building useful delay behaviors such as the ones in previous examples. See the `Retry.DelayStreams` module docs for full details and addition behavior not covered here. For convenience these functions are imported by `use Retry` so you can, usually, use them without prefixing them with the module name.

--- a/lib/retry.ex
+++ b/lib/retry.ex
@@ -6,20 +6,20 @@ defmodule Retry do
 
   Examples
 
-  use Retry
-  import Stream
+      use Retry
+      import Stream
 
-  retry with: exp_backoff |> randomize |> cap(1000) |> expiry(10000) do
-  # interact with external service
-  end
+      retry with: exp_backoff |> randomize |> cap(1000) |> expiry(10000) do
+      # interact with external service
+      end
 
-  retry with: lin_backoff(10, @fibonacci) |> cap(1000) |> take(10) do
-  # interact with external service
-  end
+      retry with: lin_backoff(10, @fibonacci) |> cap(1000) |> take(10) do
+      # interact with external service
+      end
 
-  retry with: cycle([500]) |> take(10) do
-  # interact with external service
-  end
+      retry with: cycle([500]) |> take(10) do
+      # interact with external service
+      end
 
   The first retry will exponentially increase the delay, fudging each delay up
   to 10%, until the delay reaches 1 second and then give up after 10 seconds.
@@ -49,20 +49,20 @@ defmodule Retry do
 
   Example
 
-  use Retry
-  import Stream
+      use Retry
+      import Stream
 
-  retry with: exp_backoff |> cap(1000) |> expiry(1000) do
-  # interact with external service
-  end
+      retry with: exp_backoff |> cap(1000) |> expiry(1000) do
+      # interact with external service
+      end
 
-  retry with: linear_backoff(@fibonacci) |> cap(1000) |> take(10) do
-  # interact with external service
-  end
+      retry with: linear_backoff(@fibonacci) |> cap(1000) |> take(10) do
+      # interact with external service
+      end
 
-  retry with: cycle([500]) |> take(10) do
-  # interact with external service
-  end
+      retry with: cycle([500]) |> take(10) do
+      # interact with external service
+      end
 
   """
   defmacro retry([with: stream_builder], do: block) do
@@ -91,11 +91,9 @@ defmodule Retry do
 
   Example
 
-  ```elixir
-  retry 5 in 500 do
-  # interact with external service
-  end
-  ```
+      retry 5 in 500 do
+      # interact with external service
+      end
 
   Runs the block up to 5 times with a half second sleep between each
   attempt. Execution is deemed a failure if the block returns `{:error, _}` or
@@ -115,11 +113,9 @@ defmodule Retry do
 
   Example
 
-  ```elixir
-  backoff 1000, delay_cap: 100 do
-  # interact the external service
-  end
-  ```
+      backoff 1000, delay_cap: 100 do
+      # interact the external service
+      end
 
   Runs the block repeated until it succeeds or 1 second elapses with an
   exponentially increasing delay between attempts. Execution is deemed a failure

--- a/lib/retry.ex
+++ b/lib/retry.ex
@@ -74,7 +74,7 @@ defmodule Retry do
       final_result = Enum.reduce_while(delays, nil, fn(delay, _last_result) ->
         :timer.sleep(delay)
         fun.()
-      end )
+      end)
 
       case final_result do
         {:exception, e} -> raise e
@@ -105,7 +105,7 @@ defmodule Retry do
   defmacro retry({:in, _, [retries, sleep]}, do: block) do
     quote do
       import Stream
-  retry([with: cycle([unquote(sleep)]) |> take(unquote(retries))], do: unquote(block))
+  retry([with: [unquote(sleep)] |> cycle |> take(unquote(retries))], do: unquote(block))
     end
   end
 
@@ -134,14 +134,25 @@ defmodule Retry do
     quote do
       import Stream
 
-      retry([with: exp_backoff |> randomize |> expiry(unquote(time_budget))], do: unquote(block))
+      retry(
+        [with: exp_backoff
+               |> randomize
+               |> expiry(unquote(time_budget))],
+        do: unquote(block)
+      )
     end
   end
   defmacro backoff(time_budget, delay_cap: delay_cap, do: block) do
     quote do
       import Stream
 
-      retry([with: exp_backoff |> randomize |> cap(unquote(delay_cap)) |> expiry(unquote(time_budget))], do: unquote(block))
+      retry(
+        [with: exp_backoff
+               |> randomize
+               |> cap(unquote(delay_cap))
+               |> expiry(unquote(time_budget))],
+        do: unquote(block)
+      )
     end
   end
 

--- a/lib/retry.ex
+++ b/lib/retry.ex
@@ -1,14 +1,88 @@
 defmodule Retry do
   @moduledoc """
-  Retry functions.
+
+  Provides a convenient interface to retrying behavior. All durations a
+  specified in milliseconds.
+
+  Examples
+
+  use Retry
+  import Stream
+
+  retry with: exp_backoff |> randomize |> cap(1000) |> expiry(10000) do
+  # interact with external service
+  end
+
+  retry with: lin_backoff(10, @fibonacci) |> cap(1000) |> take(10) do
+  # interact with external service
+  end
+
+  retry with: cycle([500]) |> take(10) do
+  # interact with external service
+  end
+
+  The first retry will exponentially increase the delay, fudging each delay up
+  to 10%, until the delay reaches 1 second and then give up after 10 seconds.
+
+  The second retry will linearly increase the retry from 10ms following a
+  Fibonacci pattern giving up after 10 attempts.
+
+  The third example show how we can product a delay stream using standard
+  `Stream` functionality. Any stream of integers may be used as the value of
+  `with:`.
+
+
   """
 
   @doc false
   defmacro __using__(_opts) do
     quote do
       import Retry
+      import Retry.DelayStreams
     end
   end
+
+  @doc """
+
+  Retry a block of code delaying between each attempt the duration specified by
+  the next item in the `with` delay stream.
+
+  Example
+
+  use Retry
+  import Stream
+
+  retry with: exp_backoff |> cap(1000) |> expiry(1000) do
+  # interact with external service
+  end
+
+  retry with: linear_backoff(@fibonacci) |> cap(1000) |> take(10) do
+  # interact with external service
+  end
+
+  retry with: cycle([500]) |> take(10) do
+  # interact with external service
+  end
+
+  """
+  defmacro retry([with: stream_builder], do: block) do
+    quote do
+      fun = unquote(block_runner(block))
+      retry_delays = unquote(stream_builder)
+      delays = Stream.concat([0], retry_delays)
+
+      final_result = Enum.reduce_while(delays, nil, fn(delay, _last_result) ->
+        :timer.sleep(delay)
+        fun.()
+      end )
+
+      case final_result do
+        {:exception, e} -> raise e
+        result          -> result
+      end
+    end
+  end
+
 
   @doc """
 
@@ -19,7 +93,7 @@ defmodule Retry do
 
   ```elixir
   retry 5 in 500 do
-    # interact with external service
+  # interact with external service
   end
   ```
 
@@ -30,10 +104,8 @@ defmodule Retry do
   """
   defmacro retry({:in, _, [retries, sleep]}, do: block) do
     quote do
-      do_retry(
-        fixed_delays(unquote(retries), unquote(sleep)),
-        unquote(block_runner(block))
-      )
+      import Stream
+  retry([with: cycle([unquote(sleep)]) |> take(unquote(retries))], do: unquote(block))
     end
   end
 
@@ -45,7 +117,7 @@ defmodule Retry do
 
   ```elixir
   backoff 1000, delay_cap: 100 do
-    # interact the external service
+  # interact the external service
   end
   ```
 
@@ -60,40 +132,19 @@ defmodule Retry do
   """
   defmacro backoff(time_budget, do: block) do
     quote do
-      do_retry(
-        exp_backoff_delays(unquote(time_budget), :infinity),
-        unquote(block_runner(block))
-      )
+      import Stream
+
+      retry([with: exp_backoff |> randomize |> expiry(unquote(time_budget))], do: unquote(block))
     end
   end
   defmacro backoff(time_budget, delay_cap: delay_cap, do: block) do
     quote do
-      do_retry(
-        exp_backoff_delays(unquote(time_budget), unquote(delay_cap)),
-        unquote(block_runner(block))
-      )
+      import Stream
+
+      retry([with: exp_backoff |> randomize |> cap(unquote(delay_cap)) |> expiry(unquote(time_budget))], do: unquote(block))
     end
   end
 
-  @doc """
-
-  Executes fun until it succeeds or we have run out of retry_delays. Each retry
-  is preceded by a sleep of the specified retry delay.
-
-  """
-  def do_retry(retry_delays, fun) do
-    delays = [0] |> Stream.concat(retry_delays)
-
-    final_result = delays |> Enum.reduce_while(nil, fn(delay, _last_result) ->
-      :timer.sleep(delay)
-      fun.()
-    end)
-
-    case final_result do
-      {:exception, e} -> raise e
-      result          -> result
-    end
-  end
 
   defp block_runner(block) do
     quote do
@@ -109,47 +160,5 @@ defmodule Retry do
         end
       end
     end
-  end
-
-  @doc """
-
-  Returns stream of delays that are exponentially increasing. Stream halts once
-  the specified budget of milliseconds has elapsed.
-
-  """
-  def exp_backoff_delays(budget, delay_cap) do
-    {1, :os.system_time(:milli_seconds) + budget}
-    |> Stream.unfold(fn {failures, end_t} ->
-      next_delay = figure_exp_delay(failures, delay_cap)
-      now_t = :os.system_time(:milli_seconds)
-
-      cond do
-        now_t > end_t ->
-          nil   # out of time
-        (now_t + next_delay) > end_t ->
-          {end_t - now_t, {failures + 1, end_t}}   # one last try
-        true ->
-          {next_delay, {failures + 1, end_t}}
-      end
-    end)
-  end
-
-  @doc """
-  Returns stream that returns specified number of the specified delay.
-  """
-  def fixed_delays(count, delay) do
-    [delay]
-    |> Stream.cycle
-    |> Stream.take(count)
-  end
-
-  defp figure_exp_delay(failures, :infinity) do
-    :erlang.round((1 + :random.uniform) * 10 * :math.pow(2, failures))
-  end
-  defp figure_exp_delay(failures, delay_cap) do
-    Enum.min([
-      figure_exp_delay(failures, :infinity),
-      delay_cap
-    ])
   end
 end

--- a/lib/retry/delay_streams.ex
+++ b/lib/retry/delay_streams.ex
@@ -85,20 +85,18 @@ defmodule Retry.DelayStreams do
 
   """
   def cap(delays, max) do
-    Stream.map(delays, fn d ->
-      if d <= max do
-        d
-      else
-        max
+    Stream.map(delays,
+      fn d when d <= max -> d
+        _  -> max
       end
-    end)
+    )
   end
 
   @doc """
 
-  Returns a delay stream thatthat is the same as `delays` except it limits the
-  total life span of the stream to `time_budget`. This calculation take the
-  execution time of the block being retried into account.
+  Returns a delay stream that is the same as `delays` except it limits the total
+  life span of the stream to `time_budget`. This calculation takes the execution
+  time of the block being retried into account.
 
   Example
 

--- a/lib/retry/delay_streams.ex
+++ b/lib/retry/delay_streams.ex
@@ -1,0 +1,131 @@
+defmodule Retry.DelayStreams do
+  @moduledoc """
+
+  This module provide a set of helper functions that produce delay streams for
+  use with `retry`.
+
+  """
+
+
+  @doc """
+
+  Returns a stream of delays that increase exponentially.
+
+  Example
+
+      retry exp_backoff do
+        # ...
+      end
+
+  """
+  def exp_backoff do
+    Stream.unfold(1, fn failures ->
+      {:erlang.round(10 * :math.pow(2, failures)), failures+1}
+    end )
+  end
+
+  @doc """
+
+  Returns a stream of delays that increase linearly.
+
+  Example
+
+      retry lin_backoff(@fibonacci) do
+        # ...
+      end
+
+  """
+  def lin_backoff(initial_delay, factor) do
+    Stream.unfold(initial_delay, fn last_delay ->
+      next_d = last_delay * factor
+
+      {next_d, next_d}
+    end )
+  end
+
+  @doc """
+
+  Returns a stream in which each element of `delays` is randomly adjusted no
+  more than `proportion` of the delay.
+
+  Example
+
+      retry exp_backoff |> randomize do
+        # ...
+      end
+
+
+  Produces an exponentially increasing delay stream where each delay is randomly
+  adjusted to be within 10 percent of the original value
+
+
+  """
+  def randomize(delays, proportion \\ 0.1) do
+    Stream.map(delays, fn d ->
+      max_delta = d * proportion |> round
+      shift = :rand.uniform( 2 * max_delta) - max_delta
+
+      d + shift
+    end )
+  end
+
+  @doc """
+
+  Returns a stream that is the same as `delays` except that the delays never
+  exceed `max`. This allow capping the delay between attempts to some max value.
+
+  Example
+
+      retry exp_backoff |> cap(10_000) do
+        # ...
+      end
+
+  Produces an exponentially increasing delay stream until the delay reaches 10
+  seconds at which point it stops increasing
+
+  """
+  def cap(delays, max) do
+    Stream.map(delays, fn d ->
+      if d <= max do
+        d
+      else
+        max
+      end
+    end )
+  end
+
+  @doc """
+
+  Returns a delay stream thatthat is the same as `delays` except it limits the
+  total life span of the stream to `time_budget`. This calculation take the
+  execution time of the block being retried into account.
+
+  Example
+
+      retry exp_backoff |> expiry(1000) do
+        # ...
+      end
+
+  Produces a delay stream that ends after 1 second has elapsed since its
+  creation.
+
+  """
+  def expiry(delays, time_budget) do
+    end_t = :os.system_time(:milli_seconds) + time_budget
+
+    Stream.transform(delays, :normal, fn preferred_delay, status ->
+      now_t = :os.system_time(:milli_seconds)
+      remaining_t = Enum.max([end_t - now_t, 0])
+
+      cond do
+        :at_end == status             # time expired!
+          -> {:halt, status}
+        preferred_delay > remaining_t  # one last try
+          ->  {[remaining_t], :at_end}
+       true
+          -> {[preferred_delay], status}
+      end
+
+    end )
+  end
+end

--- a/lib/retry/delay_streams.ex
+++ b/lib/retry/delay_streams.ex
@@ -20,8 +20,8 @@ defmodule Retry.DelayStreams do
   """
   def exp_backoff do
     Stream.unfold(1, fn failures ->
-      {:erlang.round(10 * :math.pow(2, failures)), failures+1}
-    end )
+      {:erlang.round(10 * :math.pow(2, failures)), failures + 1}
+    end)
   end
 
   @doc """
@@ -40,7 +40,7 @@ defmodule Retry.DelayStreams do
       next_d = last_delay * factor
 
       {next_d, next_d}
-    end )
+    end)
   end
 
   @doc """
@@ -62,11 +62,11 @@ defmodule Retry.DelayStreams do
   """
   def randomize(delays, proportion \\ 0.1) do
     Stream.map(delays, fn d ->
-      max_delta = d * proportion |> round
-      shift = :rand.uniform( 2 * max_delta) - max_delta
+      max_delta = round(d * proportion)
+      shift = :rand.uniform(2 * max_delta) - max_delta
 
       d + shift
-    end )
+    end)
   end
 
   @doc """
@@ -91,7 +91,7 @@ defmodule Retry.DelayStreams do
       else
         max
       end
-    end )
+    end)
   end
 
   @doc """
@@ -126,6 +126,6 @@ defmodule Retry.DelayStreams do
           -> {[preferred_delay], status}
       end
 
-    end )
+    end)
   end
 end

--- a/test/retry/delay_streams_test.exs
+++ b/test/retry/delay_streams_test.exs
@@ -1,0 +1,70 @@
+defmodule Retry.DelayStreamsTest do
+  use ExUnit.Case, async: true
+  import Retry.DelayStreams
+
+  test "exponential backoff" do
+    exp_backoff
+    |> Enum.take(5)
+    |> Enum.scan(fn (delay, last_delay) ->
+      assert delay > last_delay
+      delay
+    end )
+  end
+
+  test "lin_backoff/2" do
+    lin_backoff(10, 1.5)
+    |> Enum.take(5)
+    |> Enum.scan(fn (delay, last_delay) ->
+      assert (last_delay * 1.5) == delay
+      delay
+    end )
+  end
+
+  test "delay streams can be capped" do
+    exp_backoff
+    |> cap(1000)
+    |> Stream.take(10)
+    |> Enum.all?(&(&1 <= 1000))
+  end
+
+  test "expiry/1 limits life time" do
+    {elapsed, _} = :timer.tc fn ->
+      Stream.cycle([500])
+      |> expiry(1000)
+      |> Enum.each(&:timer.sleep(&1))
+    end
+
+    assert_in_delta elapsed/1000, 1000, 10
+  end
+
+  test "expiry/1 doesn't mess up delays" do
+    assert exp_backoff |> Enum.take(5) ==
+      exp_backoff |> expiry(1000) |> Enum.take(5)
+  end
+
+  test "ramdomize/1 randomizes streams" do
+    delays = Stream.cycle([500])
+    |> randomize
+    |> Enum.take(100)
+
+    Enum.each(delays, fn (delay) ->
+      assert_in_delta delay, 500, 500 * 0.1 + 1
+      delay
+    end )
+
+    assert Enum.any?(delays, &(&1 != 500))
+  end
+
+  test "ramdomize/2 randomizes streams" do
+    delays = Stream.cycle([500])
+    |> randomize(0.2)
+    |> Enum.take(100)
+
+    Enum.each(delays, fn (delay) ->
+      assert_in_delta delay, 500, 500 * 0.2 + 1
+      delay
+    end )
+
+    assert Enum.any?(delays, &(abs(&1 - 500) > (500 * 0.1)))
+  end
+end


### PR DESCRIPTION
This is a follow on to my previous PR. After i finished that one, it occurred to me that it would be possible to go even further in the stream direction. Doing so allows for much more reuse and composability around delay and give up behaviors.
