### PR TITLE
add Retry.retry/3 accepting list of whitelisted exceptions

### DIFF
--- a/test/retry_test.exs
+++ b/test/retry_test.exs
@@ -4,6 +4,7 @@ defmodule RetryTest do
 
   use Retry
   doctest Retry
+  defmodule CustomError, do: defexception message: "custom error!"
 
   test "retry retries execution for specified attempts when result is error tuple" do
     {elapsed, _} = :timer.tc fn ->
@@ -34,6 +35,18 @@ defmodule RetryTest do
       assert_raise RuntimeError, fn ->
         retry with: lin_backoff(500, 1) |> take(5) do
           raise "Error"
+        end
+      end
+    end
+
+    assert elapsed/1000 >= 2500
+  end
+
+  test "retry retries execution when a whitelisted exception is raised" do
+    {elapsed, _} = :timer.tc fn ->
+      assert_raise CustomError, fn ->
+        retry [CustomError], with: lin_backoff(500, 1) |> take(5) do
+          raise CustomError
         end
       end
     end


### PR DESCRIPTION
This add `Retry.retry/3` macro that accepts a list of exceptions on which a retry should happen.

connects to #10 

Currently there is one caveat, the list of exceptions must be a literal of a list of atoms.
I could not find a way to solve this ([given that `Code.eval_quoted` should not be used in macros](https://hexdocs.pm/elixir/Code.html#eval_quoted/3))
So for example adding the following tests breaks compilation:
```elixir
test "retry retries execution when a dynamic whitelisted exception is raised" do
  {elapsed, _} = :timer.tc fn ->
    whitelisted_exceptions = [CustomError]
    assert_raise CustomError, fn ->
      retry whitelisted_exceptions, with: lin_backoff(500, 1) |> take(5) do
        raise CustomError
      end
    end
  end

  assert elapsed/1000 >= 2500
end
```

/cc @safwank 