### PR TITLE
Consolidated `retry/2` by moving `exceptions` argument into `rescue_only` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ Check out the [API reference](https://hexdocs.pm/retry/api-reference.html) for t
 
 ### Retrying
 
-The `retry(exceptions, with: _, do: _)` macro provides a way to retry a block of code on failure with a variety of delay and give up behaviors. The execution of a block is considered a failure if it returns `:error`, `{:error, _}` or raises a runtime error.
+The `retry([with: _,] do: _)` macro provides a way to retry a block of code on failure with a variety of delay and give up behaviors. The execution of a block is considered a failure if it returns `:error`, `{:error, _}` or raises a runtime error.
 
-An optional list of exceptions can be specified as the first argument if you need to retry anything other than runtime errors.
+An optional list of exceptions can be specified in `:rescue_only` if you need to retry anything other than runtime errors, e.g. `retry([with: _, rescue_only: [CustomError]], do: _)`.
 
 #### Example -- exponential backoff
 
 ```elixir
-result = retry [TimeoutError], with: exp_backoff |> randomize |> expiry(10_000) do
+result = retry with: exp_backoff |> randomize |> expiry(10_000), rescue_only: [TimeoutError] do
   ExternalApi.do_something # fails if other system is down
 end
 ```

--- a/lib/retry.ex
+++ b/lib/retry.ex
@@ -46,21 +46,24 @@ defmodule Retry do
   Retry a block of code delaying between each attempt the duration specified by
   the next item in the `with` delay stream.
 
-  If the block raises any of the exceptions specified in `exceptions`, a retry will
-  be attempted. Other exceptions will not be retried. If `exceptions` is not specified,
-  it defaults to `[RuntimeError]`.
+  If the block raises any of the exceptions specified in `rescue_only`, a retry
+  will be attempted. Other exceptions will not be retried. If `rescue_only` is
+  not specified, it defaults to `[RuntimeError]`.
 
   Example
 
       use Retry
       import Stream
 
-      retry [CustomError], with: exp_backoff |> cap(1_000) |> expiry(1_000) do
-      # interact with external service
+      retry with: exp_backoff |> cap(1_000) |> expiry(1_000), rescue_only: [CustomError] do
+        # interact with external service
       end
 
   """
-  defmacro retry(exceptions \\ [RuntimeError], [with: stream_builder], do: block) do
+  defmacro retry(opts \\ [], do: block) do
+    stream_builder = opts[:with]
+    exceptions     = opts[:rescue_only] || [RuntimeError]
+
     quote do
       fun = unquote(block_runner(block, exceptions))
 

--- a/test/retry/delay_streams_test.exs
+++ b/test/retry/delay_streams_test.exs
@@ -31,20 +31,20 @@ defmodule Retry.DelayStreamsTest do
 
   test "delay streams can be capped" do
     assert exp_backoff()
-      |> cap(1_000)
+      |> cap(100)
       |> Stream.take(10)
-      |> Enum.all?(&(&1 <= 1_000))
+      |> Enum.all?(&(&1 <= 100))
   end
 
   test "expiry/1 limits lifetime" do
     {elapsed, _} = :timer.tc fn ->
-      [500]
+      [50]
       |> Stream.cycle
-      |> expiry(1_000)
+      |> expiry(100)
       |> Enum.each(&:timer.sleep(&1))
     end
 
-    assert_in_delta elapsed/1_000, 1_000, 10
+    assert_in_delta elapsed/1_000, 100, 10
   end
 
   test "expiry/1 doesn't mess up delays" do
@@ -52,13 +52,13 @@ defmodule Retry.DelayStreamsTest do
   end
 
   test "ramdomize/1 randomizes streams" do
-    delays = [500]
+    delays = [50]
       |> Stream.cycle()
       |> randomize
       |> Enum.take(100)
 
     Enum.each(delays, fn (delay) ->
-      assert_in_delta delay, 500, 500 * 0.1 + 1
+      assert_in_delta delay, 50, 50 * 0.1 + 1
       delay
     end)
 
@@ -66,16 +66,16 @@ defmodule Retry.DelayStreamsTest do
   end
 
   test "ramdomize/2 randomizes streams" do
-    delays = [500]
+    delays = [50]
       |> Stream.cycle()
       |> randomize(0.2)
       |> Enum.take(100)
 
     Enum.each(delays, fn (delay) ->
-      assert_in_delta delay, 500, 500 * 0.2 + 1
+      assert_in_delta delay, 50, 50 * 0.2 + 1
       delay
     end)
 
-    assert Enum.any?(delays, &(abs(&1 - 500) > (500 * 0.1)))
+    assert Enum.any?(delays, &(abs(&1 - 50) > (50 * 0.1)))
   end
 end

--- a/test/retry_test.exs
+++ b/test/retry_test.exs
@@ -47,7 +47,7 @@ defmodule RetryTest do
   test "retry retries execution when a whitelisted exception is raised" do
     {elapsed, _} = :timer.tc fn ->
       assert_raise CustomError, fn ->
-        retry [CustomError], with: lin_backoff(500, 1) |> take(5) do
+        retry with: lin_backoff(500, 1) |> take(5), rescue_only: [CustomError] do
           raise CustomError
         end
       end

--- a/test/retry_test.exs
+++ b/test/retry_test.exs
@@ -10,54 +10,54 @@ defmodule RetryTest do
 
   test "retry retries execution for specified attempts when result is error tuple" do
     {elapsed, _} = :timer.tc fn ->
-      result = retry with: lin_backoff(500, 1) |> take(5) do
+      result = retry with: lin_backoff(50, 1) |> take(5) do
         {:error, "Error"}
       end
 
       assert result == {:error, "Error"}
     end
 
-    assert elapsed/1000 >= 2500
+    assert elapsed/1_000 >= 250
   end
 
   test "retry retries execution for specified attempts when result is error atom" do
     {elapsed, _} = :timer.tc fn ->
-      result = retry with: lin_backoff(500, 1) |> take(5) do
+      result = retry with: lin_backoff(50, 1) |> take(5) do
         :error
       end
 
       assert result == :error
     end
 
-    assert elapsed/1000 >= 2500
+    assert elapsed/1_000 >= 250
   end
 
   test "retry retries execution for specified attempts when error is raised" do
     {elapsed, _} = :timer.tc fn ->
       assert_raise RuntimeError, fn ->
-        retry with: lin_backoff(500, 1) |> take(5) do
+        retry with: lin_backoff(50, 1) |> take(5) do
           raise "Error"
         end
       end
     end
 
-    assert elapsed/1000 >= 2500
+    assert elapsed/1_000 >= 250
   end
 
   test "retry retries execution when a whitelisted exception is raised" do
     {elapsed, _} = :timer.tc fn ->
       assert_raise CustomError, fn ->
-        retry with: lin_backoff(500, 1) |> take(5), rescue_only: [CustomError] do
+        retry with: lin_backoff(50, 1) |> take(5), rescue_only: [CustomError] do
           raise CustomError
         end
       end
     end
 
-    assert elapsed/1000 >= 2500
+    assert elapsed/1_000 >= 250
   end
 
   test "retry does not have to retry execution when there is no error" do
-    result = retry with: lin_backoff(500, 1) |> take(5) do
+    result = retry with: lin_backoff(50, 1) |> take(5) do
       {:ok, "Everything's so awesome!"}
     end
 
@@ -73,23 +73,23 @@ defmodule RetryTest do
       assert result == {:error, "Error"}
     end
 
-    assert round(elapsed/1000) in 425..450
+    assert round(elapsed/1_000) in 425..450
   end
 
   test "retry_while retries execution for specified attempts when halt is not emitted" do
     {elapsed, _} = :timer.tc fn ->
-      result = retry_while with: lin_backoff(500, 1) |> take(5) do
+      result = retry_while with: lin_backoff(50, 1) |> take(5) do
         {:cont, "not finishing"}
       end
 
       assert result == "not finishing"
     end
 
-    assert elapsed/1000 >= 2500
+    assert elapsed/1_000 >= 250
   end
 
   test "retry_while does not have to retry execution when halt is emitted" do
-    result = retry_while with: lin_backoff(500, 1) |> take(5) do
+    result = retry_while with: lin_backoff(50, 1) |> take(5) do
       {:halt, "Everything's so awesome!"}
     end
 
@@ -98,30 +98,30 @@ defmodule RetryTest do
 
   test "wait retries execution for specified attempts when result is false" do
     {elapsed, _} = :timer.tc fn ->
-      result = wait lin_backoff(500, 1) |> expiry(2_500) do
+      result = wait lin_backoff(50, 1) |> expiry(250) do
         false
       end
 
       refute result
     end
 
-    assert elapsed/1000 >= 2500
+    assert elapsed/1_000 >= 250
   end
 
   test "wait retries execution for specified attempts when result is nil" do
     {elapsed, _} = :timer.tc fn ->
-      result = wait lin_backoff(500, 1) |> take(5) do
+      result = wait lin_backoff(50, 1) |> take(5) do
         nil
       end
 
       refute result
     end
 
-    assert elapsed/1000 >= 2500
+    assert elapsed/1_000 >= 250
   end
 
   test "wait does not have to retry execution when result is truthy" do
-    result = wait lin_backoff(500, 1) |> take(2) do
+    result = wait lin_backoff(50, 1) |> take(2) do
       {:ok, "Everything's so awesome!"}
     end
 
@@ -129,7 +129,7 @@ defmodule RetryTest do
   end
 
   test "then executes only when result is truthy" do
-    result = wait lin_backoff(500, 1) |> take(2) do
+    result = wait lin_backoff(50, 1) |> take(2) do
       {:ok, "Everything's so awesome!"}
     then
       {:ok, "More awesome"}
@@ -139,7 +139,7 @@ defmodule RetryTest do
   end
 
   test "then does not execute when result remains false" do
-    result = wait lin_backoff(500, 1) |> take(2) do
+    result = wait lin_backoff(50, 1) |> take(2) do
       false
     then
       {:ok, "More awesome"}
@@ -149,7 +149,7 @@ defmodule RetryTest do
   end
 
   test "then does not execute when result remains nil" do
-    result = wait lin_backoff(500, 1) |> take(2) do
+    result = wait lin_backoff(50, 1) |> take(2) do
       nil
     then
       {:ok, "More awesome"}
@@ -159,7 +159,7 @@ defmodule RetryTest do
   end
 
   test "else does not execute when result is truthy" do
-    result = wait lin_backoff(500, 1) |> take(2) do
+    result = wait lin_backoff(50, 1) |> take(2) do
       {:ok, "Everything's so awesome!"}
     then
       {:ok, "More awesome"}
@@ -171,7 +171,7 @@ defmodule RetryTest do
   end
 
   test "else executes when result remains false" do
-    result = wait lin_backoff(500, 1) |> take(2) do
+    result = wait lin_backoff(50, 1) |> take(2) do
       false
     then
       {:ok, "More awesome"}
@@ -183,7 +183,7 @@ defmodule RetryTest do
   end
 
   test "else executes when result remains nil" do
-    result = wait lin_backoff(500, 1) |> take(2) do
+    result = wait lin_backoff(50, 1) |> take(2) do
       nil
     then
       {:ok, "More awesome"}


### PR DESCRIPTION
Hi,

#11 introduced `retry/3` to specifically cater for a list of exceptions to allow rescuing. It's great but it means having both `retry/2` and `retry/3`. I propose to have only `retry/2` and have exceptions be passed in as an option. This would also allow more flexible expansion of options in the future. 

What do you guys thinks? @safwank @neerfri 