### PR TITLE
Make it more obvious that only `RuntimeError` is caught.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ Check out the [API reference](https://hexdocs.pm/retry/api-reference.html) for t
 
 The `retry([with: _,] do: _)` macro provides a way to retry a block of code on failure with a variety of delay and give up behaviors. The execution of a block is considered a failure if it returns `:error`, `{:error, _}` or raises a runtime error.
 
-An optional list of exceptions can be specified in `:rescue_only` if you need to retry anything other than runtime errors, e.g. `retry([with: _, rescue_only: [CustomError]], do: _)`.
+**NOTE: By default, only `RuntimeError` is caught for the purposes of retrying on error.**
+
+If you need to retry anything other than `RuntimeError` to be caught, an optional list of exceptions can be specified in `:rescue_only`  e.g. `retry([with: _, rescue_only: [CustomError]], do: _)`.
 
 #### Example -- exponential backoff
 


### PR DESCRIPTION
Only `RuntimeError` is caught by default. This makes that more obvious.

I lost several days to this. :(