### PR TITLE
Allow rescue_only to be a runtime list

### DIFF
--- a/lib/retry.ex
+++ b/lib/retry.ex
@@ -205,7 +205,12 @@ defmodule Retry do
             result               -> {:halt, result}
           end
         rescue
-          e in unquote(exceptions) -> {:cont, {:exception, e}}
+          e ->
+            if e.__struct__ in unquote(exceptions) do
+              {:cont, {:exception, e}}
+            else
+              reraise e, System.stacktrace()
+            end
         end
       end
     end

--- a/test/retry_test.exs
+++ b/test/retry_test.exs
@@ -45,9 +45,11 @@ defmodule RetryTest do
   end
 
   test "retry retries execution when a whitelisted exception is raised" do
+    custom_error_list = [CustomError]
+
     {elapsed, _} = :timer.tc fn ->
       assert_raise CustomError, fn ->
-        retry with: lin_backoff(50, 1) |> take(5), rescue_only: [CustomError] do
+        retry with: lin_backoff(50, 1) |> take(5), rescue_only: custom_error_list do
           raise CustomError
         end
       end


### PR DESCRIPTION
The `Retry.retry/2` macro was generating an Elixir rescue clause based on the contents of the `rescue_only` option, the contents of which had to be known at compile time. With this change, the `rescue_only` option can be a runtime list instead.

I need this feature in order to use the `rescue_only` option in my own [external_service](https://github.com/jvoegele/external_service) library, which wraps the `retry` library in its own interface.