### PR TITLE
Removing nested quotes by using string sigil

### DIFF
--- a/lib/retry.ex
+++ b/lib/retry.ex
@@ -192,7 +192,7 @@ defmodule Retry do
   end
 
   defp build_wait(_stream_builder, _clauses) do
-    raise(ArgumentError, "invalid syntax, only \"wait\", \"then\" and \"else\" are permitted")
+    raise(ArgumentError, ~s/invalid syntax, only "wait", "then" and "else" are permitted/)
   end
 
   defp block_runner(block, exceptions) do

--- a/test/retry_test.exs
+++ b/test/retry_test.exs
@@ -197,7 +197,7 @@ defmodule RetryTest do
   end
 
   test "wait with invalid clauses raises argument error" do
-    error_message = "invalid syntax, only \"wait\", \"then\" and \"else\" are permitted"
+    error_message = ~s/invalid syntax, only "wait", "then" and "else" are permitted/
 
     assert_raise ArgumentError, error_message, fn ->
       Code.eval_string("wait [1, 2, 3], foo: :invalid", [], __ENV__)


### PR DESCRIPTION
This is more of a personal opinion / clean-up. If you wish to refuse, I won't be offended. I feel the use of the sigil is cleaner than escaping nested quotes.