### PR TITLE
Fix Dialyzer warning

### DIFF
--- a/lib/retry.ex
+++ b/lib/retry.ex
@@ -202,7 +202,7 @@ defmodule Retry do
     atoms = Keyword.get(opts, :atoms)
     exceptions = Keyword.get(opts, :rescue_only)
 
-    quote do
+    quote generated: true do
       fn ->
         try do
           case unquote(block) do


### PR DESCRIPTION
In case the block always returns {atom(), _}, the second case clause
in Retry.block_runner would never match, causing a Dialyzer
'pattern_match_cov' error:

    The pattern
    variable__

    can never match since previous clauses completely cover the type

    [...]

Let's mark the quoted code as "generated", thereby avoiding such
warnings.