### PR TITLE
Add exponential backoff with jitter

### DIFF
--- a/lib/retry/delay_streams.ex
+++ b/lib/retry/delay_streams.ex
@@ -45,6 +45,25 @@ defmodule Retry.DelayStreams do
 
   @doc """
 
+  Returns a stream in which each element of `delays` is randomly adjusted to a number
+  between 1 and the original delay.
+
+  Example
+
+      retry with: exponential_backoff() |> jitter() do
+        # ...
+      end
+
+  """
+  @spec jitter(Enumerable.t()) :: Enumerable.t()
+  def jitter(delays) do
+    Stream.map(delays, fn delay ->
+      :rand.uniform(trunc(delay))
+    end)
+  end
+
+  @doc """
+
   Returns a stream of delays that increase linearly.
 
   Example

--- a/test/retry/delay_streams_test.exs
+++ b/test/retry/delay_streams_test.exs
@@ -40,6 +40,12 @@ defmodule Retry.DelayStreamsTest do
     end
   end
 
+  describe "jitter/1" do
+    test "returns delays with jitter" do
+      assert exponential_backoff(100) |> jitter() |> Enum.take(5) != [10, 20, 40, 80, 160]
+    end
+  end
+
   describe "lin_backoff/2" do
     test "returns constant delays when factor is 1" do
       lin_backoff(10, 1)


### PR DESCRIPTION
This is a more dynamic and smooth backoff strategy than a simple exponential or even exponential piped through the randomizer, both of which will create groupings of calls at certain points in time.

See the link provided in the documentation for the function for more detailed info on the algorithm and effects.