### PR TITLE
user can setup exponential_backoff's power

### DIFF
--- a/lib/retry/delay_streams.ex
+++ b/lib/retry/delay_streams.ex
@@ -37,9 +37,9 @@ defmodule Retry.DelayStreams do
 
   """
   @spec exponential_backoff(pos_integer(), pos_integer()) :: Enumerable.t()
-  def exponential_backoff(initial_delay \\ 10, power \\ 2) do
+  def exponential_backoff(initial_delay \\ 10, factor \\ 2) do
     Stream.unfold(initial_delay, fn last_delay ->
-      {last_delay, round(last_delay * power)}
+      {last_delay, round(last_delay * factor)}
     end)
   end
 

--- a/lib/retry/delay_streams.ex
+++ b/lib/retry/delay_streams.ex
@@ -36,10 +36,10 @@ defmodule Retry.DelayStreams do
       end
 
   """
-  @spec exponential_backoff(pos_integer()) :: Enumerable.t()
-  def exponential_backoff(initial_delay \\ 10) do
+  @spec exponential_backoff(pos_integer(), pos_integer()) :: Enumerable.t()
+  def exponential_backoff(initial_delay \\ 10, power \\ 2) do
     Stream.unfold(initial_delay, fn last_delay ->
-      {last_delay, last_delay * 2}
+      {last_delay, round(last_delay * power)}
     end)
   end
 

--- a/test/retry/delay_streams_test.exs
+++ b/test/retry/delay_streams_test.exs
@@ -38,6 +38,11 @@ defmodule Retry.DelayStreamsTest do
              |> Enum.take(10_000)
              |> Enum.count() == 10_000
     end
+
+    test "when user set power index, it will return integer" do
+      assert exponential_backoff(31, 1.5) |> Enum.take(5) == [31,47,71,107,161]
+      assert exponential_backoff(1, 1.5) |> Enum.take(5) == [1,2,3,5,8]
+    end
   end
 
   describe "jitter/1" do

--- a/test/retry/delay_streams_test.exs
+++ b/test/retry/delay_streams_test.exs
@@ -39,7 +39,7 @@ defmodule Retry.DelayStreamsTest do
              |> Enum.count() == 10_000
     end
 
-    test "when user set power index, it will return integer" do
+    test "when user set factor as param, it will return integer" do
       assert exponential_backoff(31, 1.5) |> Enum.take(5) == [31, 47, 71, 107, 161]
       assert exponential_backoff(1, 1.5) |> Enum.take(5) == [1, 2, 3, 5, 8]
     end

--- a/test/retry/delay_streams_test.exs
+++ b/test/retry/delay_streams_test.exs
@@ -40,8 +40,8 @@ defmodule Retry.DelayStreamsTest do
     end
 
     test "when user set power index, it will return integer" do
-      assert exponential_backoff(31, 1.5) |> Enum.take(5) == [31,47,71,107,161]
-      assert exponential_backoff(1, 1.5) |> Enum.take(5) == [1,2,3,5,8]
+      assert exponential_backoff(31, 1.5) |> Enum.take(5) == [31, 47, 71, 107, 161]
+      assert exponential_backoff(1, 1.5) |> Enum.take(5) == [1, 2, 3, 5, 8]
     end
   end
 


### PR DESCRIPTION
We want to increase the retry interval exponentially, but this power index should be set by developer.