### PR TITLE
Fix dialyzer issue in wait macro

### DIFF
--- a/lib/retry.ex
+++ b/lib/retry.ex
@@ -175,8 +175,7 @@ defmodule Retry do
         :timer.sleep(delay)
 
         case unquote(do_clause) do
-          false = result -> {:cont, result}
-          nil = result -> {:cont, result}
+          result when result in [false, nil] -> {:cont, result}
           result -> {:halt, result}
         end
       end)


### PR DESCRIPTION
Using `wait` like this:

```elixir
@spec something() :: :foo | :bar
def something() do
  wait [10] |> Stream.cycle() |> Stream.take(10) do
    true_or_false?(true)
  after
    _ -> :foo
  else
    _ -> :bar
  end
end

@spec true_or_false?(boolean()) :: boolean()
defp true_or_false?(true), do: true
defp true_or_false?(false), do: false
```

I would receive this dialyzer issue:
```
lib/something.ex:15:pattern_match
The pattern can never match the type.

Pattern:
_ = nil

Type:
true
________________________________________________________________________________
```

I tracked it down to the pattern match against `false/nil` being separate lines. If you have a function returning `true` or `false`, you'll never match against `nil`. Dialyzer doesn't like that.

This PR fixes it, from what I can tell.