### PR TITLE
require Retry

### DIFF
--- a/lib/retry.ex
+++ b/lib/retry.ex
@@ -37,6 +37,7 @@ defmodule Retry do
   @doc false
   defmacro __using__(_opts) do
     quote do
+      require Retry
       import Retry
       import Retry.DelayStreams
     end


### PR DESCRIPTION
Since `retry` is a macro, `use Retry` needs to not `import` Retry but instead `require Retry` because that's what `require` is for