### PR TITLE
`reduce_while/3` allowing passing the accumulator through

### DIFF
--- a/lib/retry.ex
+++ b/lib/retry.ex
@@ -171,21 +171,19 @@ defmodule Retry do
     end
   end
 
-  defmacro retry_while([with: stream_builder, acc: acc_initial], do: block),
-    do: do_retry_value([acc: acc_initial, with: stream_builder], do: block)
+  defmacro retry_while(args = [with: _stream_builder, acc: _acc_initial], do: block),
+    do: do_retry_value(Enum.reverse(args), do: block)
 
-  defmacro retry_while([acc: acc_initial, with: stream_builder], do: block),
-    do: do_retry_value([acc: acc_initial, with: stream_builder], do: block)
+  defmacro retry_while(args = [acc: _acc_initial, with: _stream_builder], do: block),
+    do: do_retry_value(args, do: block)
 
   defp do_retry_value([acc: acc_initial, with: stream_builder], do: block) do
     quote do
-      var!(acc) = unquote(acc_initial)
-
       unquote(delays_from(stream_builder))
-      |> Enum.reduce_while(var!(acc), fn delay, var!(acc) ->
+      |> Enum.reduce_while(unquote(acc_initial), fn delay, acc ->
         :timer.sleep(delay)
 
-        case var!(acc) do
+        case acc do
           unquote(block)
         end
       end)

--- a/test/retry_test.exs
+++ b/test/retry_test.exs
@@ -201,6 +201,15 @@ defmodule RetryTest do
 
       assert result == "Everything's so awesome!"
     end
+
+    test "allows an accumulator to be passed through" do
+      result =
+        retry_while {:count, 0}, with: linear_backoff(50, 1) |> take(5) do
+          {:cont, count + 1}
+        end
+
+      assert result == 6
+    end
   end
 
   describe "wait" do

--- a/test/retry_test.exs
+++ b/test/retry_test.exs
@@ -204,11 +204,42 @@ defmodule RetryTest do
 
     test "allows an accumulator to be passed through" do
       result =
-        retry_while {:count, 0}, with: linear_backoff(50, 1) |> take(5) do
-          {:cont, count + 1}
+        retry_while acc: 0, with: linear_backoff(50, 1) |> take(5) do
+          acc -> {:cont, acc + 1}
         end
 
       assert result == 6
+    end
+
+    test "accepts any order of parameters" do
+      result =
+        retry_while with: linear_backoff(50, 1) |> take(5), acc: 0 do
+          acc -> {:cont, acc + 1}
+        end
+
+      assert result == 6
+    end
+
+    test "pattern-match in accumulator works" do
+      result =
+        retry_while acc: 0, with: linear_backoff(50, 1) |> take(5) do
+          3 -> {:halt, :ok}
+          acc -> {:cont, acc + 1}
+        end
+
+      assert result == :ok
+    end
+
+    test "responds with a meaningful error when clauses are not given" do
+      assert_raise CompileError, ~r/expected -> clauses for :do in "case"$/, fn ->
+        defmodule BadRetryWhileSyntax do
+          def retry_while do
+            retry_while with: linear_backoff(50, 1) |> take(5), acc: 0 do
+              {:cont, acc + 1}
+            end
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Th PR is inspired by [this SO question](https://stackoverflow.com/questions/69197332/can-i-capture-variable-outside-of-block-like-closure-of-other-language-in-elixir).

In some cases, subsequent retries in `reduce_while/2` might depend on the previous outcome. In such a case, it’d be great to pass the accumulator through instead of just discarding it. This PR provides `reduce_while/3` allowing this functionality.

Example

```elixir
    test "allows an accumulator to be passed through" do
      result =
        retry_while {:count, 0}, with: linear_backoff(50, 1) |> take(5) do
          {:cont, count + 1}
        end

      assert result == 6
    end
```