### PR TITLE
chore: fix links in docs and add readme so hex.pm can parse it

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -10,6 +10,10 @@ defmodule Retry.Mixfile do
       version: "0.17.0",
       elixir: "~> 1.11",
       source_url: "https://github.com/safwank/ElixirRetry",
+      docs: [
+        extras: ["README.md"],
+        source_ref: "master"
+      ],
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
Hi! Thanks for the library!

I was pairing with a friend and we were looking at the docs for this lib. This PR adds the readme and also fixes the broken link (since you use `master` rather than `main` which is the default for ExDoc.

I saw a larger PR (https://github.com/safwank/ElixirRetry/pull/39) that seems to be stale at the moment, so I figured I'd create a smaller diff to get these changes in. Hope this helps!

Thank you so much for your work! Hope this helps.

## Before
Broken link:
![image](https://user-images.githubusercontent.com/8906358/226054267-2f28cd2f-078f-48fc-8bdd-a59a359af86a.png)

Sidebar:
![image](https://user-images.githubusercontent.com/8906358/226054443-a39ad857-f35a-45b0-ae27-20a33358d87f.png)

## After
Broken link:
![image](https://user-images.githubusercontent.com/8906358/226054654-883922f9-64a4-44dd-9dbc-82543fba2083.png)

Sidebar:
![image](https://user-images.githubusercontent.com/8906358/226054753-06fc69f9-8471-4933-a01d-916eb8ae52d2.png)

