### PR TITLE
move `atom in unquote(atoms)` out of the guards

### DIFF
--- a/lib/retry.ex
+++ b/lib/retry.ex
@@ -167,14 +167,26 @@ defmodule Retry do
             unquote(else_clause)
           end
 
-        e = {atom, _} when atom in unquote(atoms) ->
-          case e do
-            unquote(else_clause)
+        e = {atom, _} ->
+          if atom in unquote(atoms) do
+            case e do
+              unquote(else_clause)
+            end
+          else
+            case e do
+              unquote(after_clause)
+            end
           end
 
-        e when is_atom(e) and e in unquote(atoms) ->
-          case e do
-            unquote(else_clause)
+        e when is_atom(e) ->
+          if e in unquote(atoms) do
+            case e do
+              unquote(else_clause)
+            end
+          else
+            case e do
+              unquote(after_clause)
+            end
           end
 
         result ->


### PR DESCRIPTION
Problem
-------

    def call(service, atoms \\ [:retry_error], rescue_only \\ [], fun) do
      retry with: delay_stream(service),
                  rescue_only: rescue_only,
                  atoms: atoms do
        # ... fun.()
      after
        result ->
          result
      else
        error ->
          error
      end
    end

This code does not comply as when Elixir tries to expand the macro the expanded code refers to "atoms" variable which can not be used in a "in" expression used in a guard.

    ** (ArgumentError) invalid right argument for operator "in", it expects a compile-time proper list or compile-time range on the right side when used in guard expressions, got: atoms

Solution
--------

Remove "in" expression from the guards to allow the `atoms` to be a variable.

@safwank What do you think?